### PR TITLE
New dashboard exp broken

### DIFF
--- a/src/app/appConfig.service.ts
+++ b/src/app/appConfig.service.ts
@@ -68,7 +68,7 @@ export class AppConfigService {
               this._identitiesClientFactory = identityFactory;
               this._coreClientFactory = coreClientFactory;
               this._context = context;
-              this._layout.widgetMode = context.getPageContext().navigation.currentController === "dashboards";
+              this._layout.widgetMode = context.getPageContext().hubsContext.selectedHubId.startsWith("ms.vss-dashboards-web");
               VSS.getService<IExtensionDataService>(VSS.ServiceIds.ExtensionData)
                   .then((service) => {
                       this._extensionDataService = service;

--- a/src/app/vss-interfaces.d.ts
+++ b/src/app/vss-interfaces.d.ts
@@ -2034,6 +2034,7 @@ interface MicrosoftAjaxConfig {
 interface HubsContext {
     HubGroupsCollectionContributionId: string;
     selectedHubGroupId: string;
+    selectedHubId: string;
     hubGroups: HubGroup[];
     hubs: Hub[];
     /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "tfs-pullrequest-dashboard",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "name": "Pull Request Dashboard",
     "description": "A pull request dashboard for Visual Studio Team Services/Team Foundation Services.",
     "publisher": "ryanstedman",

--- a/src/overview.md
+++ b/src/overview.md
@@ -82,6 +82,7 @@ Source code for this extension can be found in the [tfs-pullrequest-dashboard](h
 
 ##Change Log
 
+* (22/02/2018) 2.0.2 - bug fix: dashboard widget breaks with the new dashboards experience VSTS setting enabled.
 * (20/12/2017) 2.0.1 - fix bug when showing pull requests across all projects in a TFS deployment.
 * (17/12/2017) 2.0.0
     * Added VSTS dashboard widget


### PR DESCRIPTION
fixes the dashboard widget breaking when the new dashboard experience VSTS setting is enabled.