### PR TITLE
added recommendation for Chrome plugin to toggle CORS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,12 @@ With the local changes made, run:
 
 `npm install && npm run start`
 
-This will serve the dashboard page at localhost:8080/.  One caveat is that requests to tfs apis have cross-origin resource sharing (CORS) headers in their repsonses, which means that browsers such as chrome and firefox will not automatically handle authentication with the endpoints, and requests will fail.  To work around this issue, either use IE (which does not have this CORS restriction), or run chrome without web security.  See <http://stackoverflow.com/a/19317888> for instructions.
+This will serve the dashboard page at localhost:8080/.  One caveat is that requests to tfs apis have cross-origin resource sharing (CORS) headers in their repsonses, which means that browsers such as chrome and firefox will not automatically handle authentication with the endpoints, and requests will fail.
+
+To work around this issue:
+- either use IE (which does not have this CORS restriction)
+- run chrome without web security. See <http://stackoverflow.com/a/19317888> for instructions.
+- Install [this Chrome plugin](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?hl=en) which allows you to easily toggle CORS restrictions on and off
 
 ### Packaging
 


### PR DESCRIPTION
I use [this Chrome plugin](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi?hl=en) which makes toggling CORS restrictions on and off a breeze. It's far simpler that running Chrome without web security and has made working with this project much more enjoyable for me.

I've added it to the README as a suggestion.