### PR TITLE
fix(manifest): icon for hub in new navigation

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,6 +41,12 @@
             "properties": {
                 "name": "Pull Request Dashboard",
                 "order": 99,
+                "iconAsset": "tfs-pullrequest-dashboard/assets/images/logo.png",
+                "_sharedData": {
+                    "assets": [
+                        "tfs-pullrequest-dashboard/assets/images/logo.png"
+                    ]
+                },
                 "uri": "index.html"
             }
         },


### PR DESCRIPTION
This should fix the icon on the new navigation hub (which is currently the ugly square box). Check out the docs at: https://docs.microsoft.com/en-us/azure/devops/extend/develop/web-navigation?view=azure-devops#hub-icon