### PR TITLE
Implement a user setting to hide draft PRs.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,6 +21,13 @@
                   </label>
                   <span id="allProjectsHelp" class="help-block">Show PRs from repos across all projects.</span>
                 </div>
+                <div class="form-check">
+                  <label class="form-check-label">
+                    <input type="checkbox" class="form-check-input" id="inputHideDraftPRs" [(ngModel)]="hideDraftPRs" (ngModelChange)="onHideDraftPRsChanged($event)" name="hideDraftPRs" aria-describedby="hideDraftPRsHelp">
+                    Hide Draft PRs
+                  </label>
+                  <span id="hideDraftPRsHelp" class="help-block">Hide pull requests marked as draft.</span>
+                </div>
               </div>
             </li>
           </form>

--- a/src/app/model.ts
+++ b/src/app/model.ts
@@ -101,6 +101,8 @@ export abstract class AppSettingsService {
     public static dateFormatKey = "dateFormat";
     // settings key for showing PRs across all projects instead of just the current
     public static allProjectsKey = "allProjects";
+    // settings key for hiding draft PRs
+    public static hideDraftPRsKey = "hideDraftPRs";
 
     public static defaultDateFormat = "dd/MM/yyyy HH:mm";
 
@@ -146,6 +148,18 @@ export abstract class AppSettingsService {
 
     public async setShowAllProjects(value: boolean): Promise<void> {
         await this.setValue(AppSettingsService.allProjectsKey, value.toString());
+    }
+
+    public async getHideDraftPRs(): Promise<boolean> {
+        const savedHideDraftPRs = await this.getValue(AppSettingsService.hideDraftPRsKey);
+        if (savedHideDraftPRs === "true") {
+            return true;
+        }
+        return false;
+    }
+
+    public async setHideDraftPRs(value: boolean): Promise<void> {
+        await this.setValue(AppSettingsService.hideDraftPRsKey, value.toString());
     }
 
     public getLayout(): Layout {

--- a/src/overview.md
+++ b/src/overview.md
@@ -51,6 +51,7 @@ At the top right of the dashboard plugin is a button which will drop down user-s
 
 * Date Format - specifies the format to display PR creation date timestamp.  Default is "dd/MM/yyyy HH:mm".
 * All Projects - show pull requests from repositories across all projects.
+* Hide Draft PRs - hide pull requests marked as draft.
 
 ![Settings](assets/screenshots/settings.png)
 

--- a/test/app.component.spec.ts
+++ b/test/app.component.spec.ts
@@ -64,6 +64,7 @@ describe("AppComponent", () => {
         spyOn(settingsMock, "getDateFormat");
         spyOn(settingsMock, "getRepoFilter");
         spyOn(settingsMock, "getShowAllProjects");
+        spyOn(settingsMock, "getHideDraftPRs");
 
         zoneMock = {
             run: (action: () => void) => action(),
@@ -88,6 +89,7 @@ describe("AppComponent", () => {
         expect(settingsMock.getDateFormat).toHaveBeenCalledTimes(0);
         expect(settingsMock.getRepoFilter).toHaveBeenCalledTimes(0);
         expect(settingsMock.getShowAllProjects).toHaveBeenCalledTimes(0);
+        expect(settingsMock.getHideDraftPRs).toHaveBeenCalledTimes(0);
     });
 
 });


### PR DESCRIPTION
Provides a user setting to filter out draft PRs from the view that often cause clutter and are not ready to be reviewed anyway.

resolves #67 - other than that this implementation excludes all draft PRs when active, rather than just those raised by somebody else.